### PR TITLE
Closures to controllers

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,8 @@
 <?php
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use Laravel\Nova\Nova;
-use Zttp\Zttp;
+use Tightenco\NovaReleases\Http\Controllers\ReleasesController;
+use Tightenco\NovaReleases\Http\Controllers\InstalledVersionController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,16 +15,5 @@ use Zttp\Zttp;
 |
 */
 
-Route::get('releases', function (Request $request) {
-    $data = Cache::remember('tightenco-nova-releases::releases', 60, function () {
-        // @todo: Cache it on novapackages.com so as to save load on the Nova folks <3
-        $response = Zttp::get('https://nova.laravel.com/api/releases');
-        return $response->json();
-    });
-
-    return response()->json($data);
-});
-
-Route::get('installed-version', function (Request $request) {
-    return response()->json(['installed_version' => Nova::version()]);
-});
+Route::get('releases', ReleasesController::class);
+Route::get('installed-version', InstalledVersionController::class);

--- a/src/Http/Controllers/InstalledVersionController.php
+++ b/src/Http/Controllers/InstalledVersionController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tightenco\NovaReleases\Http\Controllers;
+
+use Laravel\Nova\Nova;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class InstalledVersionController extends Controller
+{
+    public function __invoke()
+    {
+        return response()->json(['installed_version' => Nova::version()]);
+    }
+}

--- a/src/Http/Controllers/ReleasesController.php
+++ b/src/Http/Controllers/ReleasesController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tightenco\NovaReleases\Http\Controllers;
+
+use Zttp\Zttp;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Cache;
+
+class ReleasesController extends Controller
+{
+    public function __invoke()
+    {
+        $data = Cache::remember('tightenco-nova-releases::releases', 60, function () {
+            // @todo: Cache it on novapackages.com so as to save load on the Nova folks <3
+            $response = Zttp::get('https://nova.laravel.com/api/releases');
+            return $response->json();
+        });
+    
+        return response()->json($data);
+    }
+}


### PR DESCRIPTION
Moved closure routes into controllers so that they can be cached using route:cache.

Resolves issue #1.